### PR TITLE
Swapped to ember-cli-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,94 +1,92 @@
 {
-    "name": "web-app",
-    "version": "0.0.0",
-    "description": "Small description for web-app goes here",
-    "private": true,
-    "directories": {
-        "doc": "doc",
-        "test": "tests"
+  "name": "web-app",
+  "version": "0.0.0",
+  "description": "Small description for web-app goes here",
+  "private": true,
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build",
+    "start": "tsc --target es6 --module CommonJS electron.ts && ember electron",
+    "test": "ember electron:test"
+  },
+  "repository": "",
+  "engines": {
+    "node": ">= 0.10.0"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/electron": "^1.4.30",
+    "@types/ember": "2.7.35",
+    "broccoli-asset-rev": "^2.4.2",
+    "electron-packager": "6.0.1",
+    "electron-prebuilt": "^1.3.9",
+    "electron-rebuild": "1.1.3",
+    "ember-ajax": "0.7.1",
+    "ember-cli": "2.4.3",
+    "ember-cli-app-version": "^1.0.0",
+    "ember-cli-babel": "^5.1.6",
+    "ember-cli-dependency-checker": "^1.2.0",
+    "ember-cli-htmlbars": "^1.0.3",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-inject-live-reload": "^1.4.0",
+    "ember-cli-qunit": "^1.4.0",
+    "ember-cli-release": "0.2.8",
+    "ember-cli-sri": "^2.1.0",
+    "ember-cli-typescript": "0.2.0",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-data": "^2.4.2",
+    "ember-electron": "^1.3.2",
+    "ember-export-application-global": "^1.0.5",
+    "ember-inspector": "^2.0.4",
+    "ember-load-initializers": "^0.5.1",
+    "ember-resolver": "^2.0.3",
+    "loader.js": "^4.0.1",
+    "typescript": "2.1.4"
+  },
+  "main": "electron.js",
+  "ember-electron": {
+    "WHAT IS THIS?": "Please see the README.md",
+    "copy-files": [
+      "electron.js",
+      "package.json"
+    ],
+    "name": null,
+    "platform": null,
+    "arch": null,
+    "version": null,
+    "app-bundle-id": null,
+    "app-category-type": null,
+    "app-copyright": null,
+    "app-version": null,
+    "asar": null,
+    "asar-unpack": null,
+    "asar-unpack-dir": null,
+    "build-version": null,
+    "cache": null,
+    "extend-info": null,
+    "extra-resource": null,
+    "helper-bundle-id": null,
+    "icon": null,
+    "ignore": null,
+    "out": null,
+    "osx-sign": {
+      "identity": null,
+      "entitlements": null,
+      "entitlements-inherit": null
     },
-    "scripts": {
-        "build": "ember build",
-        "start": "tsc electron.ts && ember electron",
-        "test": "ember electron:test"
-    },
-    "repository": "",
-    "engines": {
-        "node": ">= 0.10.0"
-    },
-    "author": "",
-    "license": "MIT",
-    "devDependencies": {
-        "at-types-ember": "github:winding-lines/at-types-ember",
-        "broccoli-asset-rev": "^2.4.2",
-        "electron-packager": "6.0.1",
-        "electron-prebuilt": "^1.3.9",
-        "electron-rebuild": "1.1.3",
-        "ember-ajax": "0.7.1",
-        "ember-cli": "2.4.3",
-        "ember-cli-app-version": "^1.0.0",
-        "ember-cli-babel": "^5.1.6",
-        "ember-cli-dependency-checker": "^1.2.0",
-        "ember-cli-htmlbars": "^1.0.3",
-        "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-        "ember-cli-inject-live-reload": "^1.4.0",
-        "ember-cli-qunit": "^1.4.0",
-        "ember-cli-release": "0.2.8",
-        "ember-cli-sri": "^2.1.0",
-        "ember-cli-typify": "^0.3.1",
-        "ember-cli-uglify": "^1.2.0",
-        "ember-data": "^2.4.2",
-        "ember-electron": "^1.3.2",
-        "ember-export-application-global": "^1.0.5",
-        "ember-inspector": "^2.0.4",
-        "ember-load-initializers": "^0.5.1",
-        "ember-resolver": "^2.0.3",
-        "loader.js": "^4.0.1",
-        "typescript": "^2.0.0"
-    },
-    "main": "electron.js",
-    "ember-electron": {
-        "WHAT IS THIS?": "Please see the README.md",
-        "copy-files": [
-            "electron.js",
-            "package.json"
-        ],
-        "name": null,
-        "platform": null,
-        "arch": null,
-        "version": null,
-        "app-bundle-id": null,
-        "app-category-type": null,
-        "app-copyright": null,
-        "app-version": null,
-        "asar": null,
-        "asar-unpack": null,
-        "asar-unpack-dir": null,
-        "build-version": null,
-        "cache": null,
-        "extend-info": null,
-        "extra-resource": null,
-        "helper-bundle-id": null,
-        "icon": null,
-        "ignore": null,
-        "out": null,
-        "osx-sign": {
-            "identity": null,
-            "entitlements": null,
-            "entitlements-inherit": null
-        },
-        "overwrite": null,
-        "prune": null,
-        "strict-ssl": null,
-        "version-string": {
-            "CompanyName": null,
-            "FileDescription": null,
-            "OriginalFilename": null,
-            "ProductName": null,
-            "InternalName": null
-        }
-    },
-    "dependencies": {
-        "@types/electron": "^1.4.27"
+    "overwrite": null,
+    "prune": null,
+    "strict-ssl": null,
+    "version-string": {
+      "CompanyName": null,
+      "FileDescription": null,
+      "OriginalFilename": null,
+      "ProductName": null,
+      "InternalName": null
     }
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "ember": ["node_modules/at-types-ember"],
       "npm:*": ["local-types/*"],
       "*": ["local-types/*"]
     }


### PR DESCRIPTION
ember-cli-typify is now deprecated; ember-cli-typescript is the sole recommended Ember Addon for Typescript support.